### PR TITLE
Update auth.php

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -155,7 +155,8 @@ class auth_plugin_saml2sso extends auth_plugin_base {
 
         // User Id returned from IdP
         // Will be used to get user from our Moodle database if exists
-        $uid = $attributes[$this->config->idpattr][0];
+      	// create_user_record lowercases the username, so we need to lower it here.
+        $uid = trim(core_text::strtolower($attributes[$this->config->idpattr][0]));
 
         // Now we check if the Id returned from IdP exists in our Moodle database
         $isuser = $DB->get_record('user', array($this->config->mdlattr => $uid));


### PR DESCRIPTION
Lowercase username when checking if user already exists as create_user_record lowercases it before insertion.

Postgresql default install for Moodle uses case sensitive collation.

If auto-create accounts is enabled, the account will be created and login will work for that session. As soon as you hit logout and try and login again, you receive a DML exception as Moodle attempts to insert the record to the DB with 'create_user_record' - it violates the unique index, as it already exists in the lowercase form.

Code is cribbed from auth/manual, but we don't check the mnet id, may be bug or feature.