### PR TITLE
Fixed PHP deprecations

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -65,6 +65,8 @@ class auth_plugin_saml2sso extends auth_plugin_base {
         'idnumber' => 'idnumber',
     );
 
+    public object $mapping;
+
     /**
      * Constructor
      */

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024120100;              // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version = 2024121900;              // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires = 2018111800;             // Requires this Moodle version
 $plugin->component = 'auth_saml2sso';       // Full name of the plugin (used for diagnostics)
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '4.5.0';
+$plugin->release = '4.5.1';


### PR DESCRIPTION
A global variable was never added to $mapping, or perhaps removed in Moodle parent file.
It is now added in the file, so no error occurs.